### PR TITLE
Fixed errors about not being able to call write on undefined

### DIFF
--- a/src/components/utils/directory-tree.js
+++ b/src/components/utils/directory-tree.js
@@ -1,7 +1,7 @@
 // https://github.com/mihneadb/node-directory-tree/blob/1c1d350934698fb9cf8dbab27afb970725ddd7b5/lib/directory-tree.js
 // put memfs into it instead
 
-import { fs as FS } from 'memfs';
+import { fs as FS } from '../../globals';
 import * as PATH from 'path';
 
 const constants = {
@@ -14,7 +14,7 @@ function safeReadDirSync(path) {
   try {
     dirData = FS.readdirSync(path);
   } catch (ex) {
-    if (ex.code == 'EACCES' || ex.code == 'EPERM') {
+    if (ex.code === 'EACCES' || ex.code === 'EPERM') {
       //User does not have permissions, ignore directory
       return null;
     } else throw ex;

--- a/src/components/workspace/Explorer.js
+++ b/src/components/workspace/Explorer.js
@@ -4,7 +4,7 @@ import TreeView from '@mui/lab/TreeView';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import directoryTree from '../utils/directory-tree';
-import fs from 'memfs';
+import { fs } from '../../globals';
 import TreeItem from '@mui/lab/TreeItem';
 import { css } from '@emotion/react';
 

--- a/src/components/workspace/console/clear.js
+++ b/src/components/workspace/console/clear.js
@@ -1,0 +1,14 @@
+export function register(shell) {
+  shell.term.onKey((evt) => {
+    // ctrl+l
+    if (evt.key === '\f') {
+      shell.term.clear();
+    }
+  });
+
+  shell.command('clear', async (shell, args, opts) => {
+    setTimeout(() => {
+      shell.shell.term.clear();
+    }, 0);
+  });
+}

--- a/src/components/workspace/console/git.js
+++ b/src/components/workspace/console/git.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { fs } from 'react-ode-cash-money';
+import { fs } from '../../../globals';
 import http from 'isomorphic-git/http/web';
 import git from 'isomorphic-git';
 

--- a/src/components/workspace/console/index.js
+++ b/src/components/workspace/console/index.js
@@ -1,10 +1,12 @@
 import * as git from './git';
 import * as shx from './shell';
 import * as reactOde from './react-ode';
+import * as clear from './clear';
 export * as addons from './addons';
 
 export function registerApplications(shell) {
   git.register(shell);
   reactOde.register(shell);
   shx.register(shell);
+  clear.register(shell);
 }

--- a/src/components/workspace/console/shell.js
+++ b/src/components/workspace/console/shell.js
@@ -1,14 +1,15 @@
 import { createShell } from 'shelljs-core';
 import stringArgv from 'string-argv';
+import globals from '../../../globals';
 
 export function register(terminal) {
   const ignore = ['exit', 'error', 'ShellString', 'env', 'config'];
   const shelljs = createShell({
-    fs: require('memfs'),
-    os: require('os-browserify/browser'),
-    path: require('path-browserify'),
-    util: require('util/'),
-    process: require('process/browser'),
+    fs: globals.fs,
+    os: globals.os,
+    path: globals.path,
+    util: globals.util,
+    process: globals.process,
     console,
   });
   Object.keys(shelljs)
@@ -16,8 +17,13 @@ export function register(terminal) {
     .forEach((cmd) => {
       terminal.command(cmd, async (shell, args, orgOpts) => {
         const argv = stringArgv(terminal.currentLine());
-        const res = shelljs[cmd].apply(null, argv.slice(1));
-        shell.printLine(res.stderr || res.stdout);
+        try {
+          const res = shelljs[cmd].apply(shell, argv.slice(1));
+          shell.printLine(res.stderr || res.stdout);
+        } catch (e) {
+          console.log(e);
+          throw e;
+        }
       });
     });
 }

--- a/src/globals.js
+++ b/src/globals.js
@@ -1,0 +1,30 @@
+export const fs = require('memfs');
+export const os = require('os-browserify/browser');
+export const path = require('path-browserify');
+export const util = require('util/');
+export const process = require('process/browser');
+
+process.chdir = function (dir) {
+  this.cwd = () => {
+    return path.resolve(dir);
+  };
+};
+process.listenerCount = function (sym) {
+  return this.listeners ? this.listeners(sym).length : 0;
+};
+process.hrtime = require('browser-process-hrtime');
+
+process.stderr = {
+  write: (...args) => console.error('stderr', ...args),
+};
+process.stdout = {
+  write: (...args) => console.log('stdout', ...args),
+};
+const globalState = {
+  fs,
+  os,
+  path,
+  util,
+  process,
+};
+export default globalState;


### PR DESCRIPTION
Commands like "echo 'what'" were not working because the shelljs instances had nothing to write to. Simple fix was to run in the scope of the shell. I also added globals which I thought I needed for process.stdout.write. I'm including this into the pr since it's a small change. Finally, I added a way to clear the terminal either by typing "clear" and hitting enter or pressing "ctrl+l".