### PR TITLE
Expose addons and applications of the console component

### DIFF
--- a/src/components/workspace/Console.js
+++ b/src/components/workspace/Console.js
@@ -32,10 +32,12 @@ export default class Console extends React.Component {
   static propTypes = {
     tabSize: PropTypes.number.isRequired,
     padding: PropTypes.number,
+    applications: PropTypes.arrayOf(PropTypes.func),
   };
 
   static defaultProps = {
     padding: 5,
+    applications: [],
   };
 
   handleConsoleData = (data) => {
@@ -65,6 +67,7 @@ export default class Console extends React.Component {
     const shell = new XtermJSShell(terminal);
     // create applications that listen for specific commands
     console.registerApplications(shell);
+    this.props.applications.forEach((application) => application(shell));
     // we hook into where XtermJSShell reads lines and save the last one
     let lastLine = '';
     const read = shell.echo.read.bind(shell.echo);


### PR DESCRIPTION
2 new props are added, addons, and applications, which
takes an array of functions. An addon must be a proper xterm
addon that has an activate and dispose method.

Applications receive an instance of shelljs and most useful
for registering applications. Set shell.command using the
xterm-js-shell api to create applications.